### PR TITLE
7. Adr075: Backport rpc/client rewrite the WaitForOneEvent helper (#7986)

### DIFF
--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -1,6 +1,9 @@
 package proxy
 
 import (
+	"time"
+
+	"github.com/tendermint/tendermint/internal/eventlog/cursor"
 	"github.com/tendermint/tendermint/libs/bytes"
 	lrpc "github.com/tendermint/tendermint/light/rpc"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
@@ -14,7 +17,7 @@ func RPCRoutes(c *lrpc.Client) map[string]*rpcserver.RPCFunc {
 	return map[string]*rpcserver.RPCFunc{
 		// Event subscription. Note that subscribe, unsubscribe, and
 		// unsubscribe_all are only available via the websocket endpoint.
-		"events":          rpcserver.NewRPCFunc(c.Events, "filter,maxItems,before,after,waitTime"),
+		"events":          rpcserver.NewRPCFunc(makeEventsSearchFunc(c), "filter,maxItems,before,after,waitTime"),
 		"subscribe":       rpcserver.NewWSRPCFunc(c.SubscribeWS, "query"),
 		"unsubscribe":     rpcserver.NewWSRPCFunc(c.UnsubscribeWS, "query"),
 		"unsubscribe_all": rpcserver.NewWSRPCFunc(c.UnsubscribeAllWS, ""),
@@ -284,5 +287,31 @@ type rpcBroadcastEvidenceFunc func(ctx *rpctypes.Context, ev types.Evidence) (*c
 func makeBroadcastEvidenceFunc(c *lrpc.Client) rpcBroadcastEvidenceFunc {
 	return func(ctx *rpctypes.Context, ev types.Evidence) (*ctypes.ResultBroadcastEvidence, error) {
 		return c.BroadcastEvidence(ctx.Context(), ev)
+	}
+}
+
+type rpcEventsSearchFunc func(
+	ctx *rpctypes.Context,
+	filter *ctypes.EventFilter,
+	maxItems int,
+	before, after cursor.Cursor,
+	waitTime time.Duration,
+) (*ctypes.ResultEvents, error)
+
+func makeEventsSearchFunc(c *lrpc.Client) rpcEventsSearchFunc {
+	return func(
+		ctx *rpctypes.Context,
+		filter *ctypes.EventFilter,
+		maxItems int,
+		before, after cursor.Cursor,
+		waitTime time.Duration,
+	) (*ctypes.ResultEvents, error) {
+		return c.Events(ctx.Context(), &ctypes.RequestEvents{
+			Filter:   filter,
+			MaxItems: maxItems,
+			WaitTime: waitTime,
+			Before:   before.String(),
+			After:    after.String(),
+		})
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1099,6 +1099,7 @@ func (n *Node) ConfigureRPC() error {
 		BlockIndexer:     n.blockIndexer,
 		ConsensusReactor: n.consensusReactor,
 		EventBus:         n.eventBus,
+		EventLog:         n.eventLog,
 		Mempool:          n.mempool,
 
 		Logger: n.Logger.With("module", "rpc"),

--- a/rpc/client/event_test.go
+++ b/rpc/client/event_test.go
@@ -44,10 +44,9 @@ func TestHeaderEvents(t *testing.T) {
 			ectx, cancel := context.WithTimeout(ctx, waitForEventTimeout)
 			defer cancel()
 			query := types.QueryForEvent(types.EventNewBlockHeader).String()
-			evt, err := client.WaitForOneEvent(ectx, c, query)
+			var evt types.EventDataNewBlockHeader
+			err := client.WaitForOneEvent(ectx, c, query, &evt)
 			require.Nil(t, err, "%d: %+v", i, err)
-			_, ok := evt.(types.EventDataNewBlockHeader)
-			require.True(t, ok, "%d: %#v", i, evt)
 			// TODO: more checks...
 		})
 	}
@@ -144,16 +143,13 @@ func testTxEventsSent(t *testing.T, broadcastMethod string) {
 
 			// Wait for the transaction we sent to be confirmed.
 			query := fmt.Sprintf(`tm.event = '%s' AND tx.hash = '%X'`, types.EventTx, types.Tx(tx).Hash())
-			evt, err := client.WaitForOneEvent(ctx, c, query)
+			var evt types.EventDataTx
+			err := client.WaitForOneEvent(ctx, c, query, &evt)
 			require.Nil(t, err)
 
-			// and make sure it has the proper info
-			txe, ok := evt.(types.EventDataTx)
-			require.True(t, ok)
-
 			// make sure this is the proper tx
-			require.EqualValues(t, tx, txe.Tx)
-			require.True(t, txe.Result.IsOK())
+			require.EqualValues(t, tx, evt.Tx)
+			require.True(t, evt.Result.IsOK())
 		})
 	}
 }

--- a/rpc/client/helpers.go
+++ b/rpc/client/helpers.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -52,32 +53,25 @@ func WaitForHeight(c StatusClient, h int64, waiter Waiter) error {
 	return nil
 }
 
-// WaitForOneEvent subscribes to a websocket event for the given
-// event time and returns upon receiving it one time, or
-// when the timeout duration has expired.
-//
-// This handles subscribing and unsubscribing under the hood
-func WaitForOneEvent(c SubscriptionClient, evtTyp string, timeout time.Duration) (types.TMEventData, error) {
-	const subscriber = "helpers"
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	// register for the next event of this type
-	eventCh, err := c.Subscribe(ctx, subscriber, types.QueryForEvent(evtTyp).String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe: %w", err)
-	}
-	// make sure to unregister after the test is over
-	defer func() {
-		if deferErr := c.UnsubscribeAll(ctx, subscriber); deferErr != nil {
-			panic(deferErr)
+// WaitForOneEvent waits for the first event matching the given query on c, or
+// until ctx ends. It reports an error if ctx ends before a matching event is
+// received.
+func WaitForOneEvent(ctx context.Context, c EventsClient, query string) (types.TMEventData, error) {
+	for {
+		rsp, err := c.Events(ctx, &coretypes.RequestEvents{
+			Filter:   &coretypes.EventFilter{Query: query},
+			MaxItems: 1,
+			WaitTime: 10 * time.Second, // duration doesn't matter, limited by ctx timeout
+		})
+		if err != nil {
+			return nil, err
+		} else if len(rsp.Items) == 0 {
+			continue // continue polling until ctx expires
 		}
-	}()
-
-	select {
-	case event := <-eventCh:
-		return event.Data, nil
-	case <-ctx.Done():
-		return nil, errors.New("timed out waiting for event")
+		var result types.TMEventData
+		if err := json.Unmarshal(rsp.Items[0].Data, &result); err != nil {
+			return nil, err
+		}
+		return result, nil
 	}
 }

--- a/rpc/client/helpers.go
+++ b/rpc/client/helpers.go
@@ -56,7 +56,7 @@ func WaitForHeight(c StatusClient, h int64, waiter Waiter) error {
 // WaitForOneEvent waits for the first event matching the given query on c, or
 // until ctx ends. It reports an error if ctx ends before a matching event is
 // received.
-func WaitForOneEvent(ctx context.Context, c EventsClient, query string) (types.TMEventData, error) {
+func WaitForOneEvent(ctx context.Context, c EventsClient, query string, evt types.TMEventData) error {
 	for {
 		rsp, err := c.Events(ctx, &coretypes.RequestEvents{
 			Filter:   &coretypes.EventFilter{Query: query},
@@ -64,14 +64,13 @@ func WaitForOneEvent(ctx context.Context, c EventsClient, query string) (types.T
 			WaitTime: 10 * time.Second, // duration doesn't matter, limited by ctx timeout
 		})
 		if err != nil {
-			return nil, err
+			return err
 		} else if len(rsp.Items) == 0 {
 			continue // continue polling until ctx expires
 		}
-		var result types.TMEventData
-		if err := json.Unmarshal(rsp.Items[0].Data, &result); err != nil {
-			return nil, err
+		if err := json.Unmarshal(rsp.Items[0].Data, evt); err != nil {
+			return err
 		}
-		return result, nil
+		return nil
 	}
 }

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tendermint/tendermint/internal/eventlog/cursor"
+
 	"github.com/tendermint/tendermint/libs/bytes"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
@@ -364,11 +366,18 @@ func (c *baseRPCClient) ConsensusParams(
 func (c *baseRPCClient) Events(ctx context.Context, req *ctypes.RequestEvents) (*ctypes.ResultEvents, error) {
 	result := new(ctypes.ResultEvents)
 	// FIXME monstrosity params
+	var before, after cursor.Cursor
+	if err := before.UnmarshalText([]byte(req.Before)); err != nil {
+		return nil, err
+	}
+	if err := after.UnmarshalText([]byte(req.After)); err != nil {
+		return nil, err
+	}
 	if _, err := c.caller.Call(ctx, "events", map[string]interface{}{
 		"filter":    req.Filter,
 		"max_items": req.MaxItems,
-		"after":     req.After,
-		"before":    req.Before,
+		"after":     after,
+		"before":    before,
 		"wait_time": req.WaitTime,
 	}, result); err != nil {
 		return nil, err

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -136,7 +136,7 @@ func (c *Local) Events(ctx context.Context, req *ctypes.RequestEvents) (*ctypes.
 	if err := after.UnmarshalText([]byte(req.After)); err != nil {
 		return nil, err
 	}
-	return core.Events(ctx, req.Filter, req.MaxItems, before, after, req.WaitTime)
+	return core.Events(c.ctx, req.Filter, req.MaxItems, before, after, req.WaitTime)
 }
 
 func (c *Local) Health(ctx context.Context) (*ctypes.ResultHealth, error) {

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -148,7 +148,7 @@ func UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
 // If maxItems ≤ 0, a default positive number of events is chosen. The values
 // of maxItems and waitTime may be capped to sensible internal maxima without
 // reporting an error to the caller.
-func Events(ctx context.Context,
+func Events(ctx *rpctypes.Context,
 	filter *ctypes.EventFilter,
 	maxItems int,
 	before, after cursor.Cursor,
@@ -200,7 +200,7 @@ func Events(ctx context.Context,
 	}
 
 	if waitTime > 0 && before.IsZero() {
-		ctx, cancel := context.WithTimeout(ctx, waitTime)
+		ctx, cancel := context.WithTimeout(ctx.Context(), waitTime)
 		defer cancel()
 
 		// Long poll. The loop here is because new items may not match the query,


### PR DESCRIPTION
Update usage in tests.

Please add a description of the changes that this PR introduces and the files that
are the most critical to review.

If this PR fixes an open Issue, please include "Closes #XXX" (where "XXX" is the Issue number) 
so that GitHub will automatically close the Issue when this PR is merged.


