### PR TITLE
10. Adr075 rpc enable the ADR 075 event log by default in new configs (#8572)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -474,7 +474,7 @@ func DefaultRPCConfig() *RPCConfig {
 		MaxSubscriptionClients:       100,
 		MaxSubscriptionsPerClient:    5,
 		ExperimentalDisableWebsocket: false, // compatible with TM v0.35 and earlier
-		EventLogWindowSize:           0,     // disables /events RPC by default
+		EventLogWindowSize:           30 * time.Second,
 		EventLogMaxItems:             0,
 
 		TimeoutBroadcastTxCommit: 10 * time.Second,


### PR DESCRIPTION
Since we are deprecating the stream-based event subscription in v0.36, we
should ensure that new nodes enable the replacement by default.  For now, just
set a baseline 30-second window.

Please add a description of the changes that this PR introduces and the files that
are the most critical to review.

If this PR fixes an open Issue, please include "Closes #XXX" (where "XXX" is the Issue number) 
so that GitHub will automatically close the Issue when this PR is merged.


