### PR TITLE
11. backport-adr075: rpc set a minimum long-polling interval for Events (#8050)

### DIFF
--- a/rpc/client/eventstream/eventstream_test.go
+++ b/rpc/client/eventstream/eventstream_test.go
@@ -109,7 +109,13 @@ func TestMinPollTime(t *testing.T) {
 		start := time.Now()
 
 		// Request a very short delay, and affirm we got the server's minimum.
-		rsp, err := s.env.Events(ctx, filter, 1, zero, zero, 10*time.Millisecond)
+		rsp, err := s.Events(ctx, &coretypes.RequestEvents{
+			Filter:   filter,
+			MaxItems: 1,
+			After:    zero.String(),
+			Before:   zero.String(),
+			WaitTime: 10 * time.Millisecond,
+		})
 		if err != nil {
 			t.Fatalf("Events failed: %v", err)
 		} else if elapsed := time.Since(start); elapsed < time.Second {
@@ -128,7 +134,13 @@ func TestMinPollTime(t *testing.T) {
 		// Request a long-ish delay and affirm we don't block for it.
 		// Check for this by ensuring we return sooner than the minimum delay,
 		// since we don't know the exact timing.
-		rsp, err := s.env.Events(ctx, filter, 1, zero, zero, 10*time.Second)
+		rsp, err := s.Events(ctx, &coretypes.RequestEvents{
+			Filter:   filter,
+			MaxItems: 1,
+			After:    zero.String(),
+			Before:   zero.String(),
+			WaitTime: 10 * time.Second,
+		})
 		if err != nil {
 			t.Fatalf("Events failed: %v", err)
 		} else if elapsed := time.Since(start); elapsed > 500*time.Millisecond {

--- a/rpc/client/eventstream/eventstream_test.go
+++ b/rpc/client/eventstream/eventstream_test.go
@@ -90,6 +90,55 @@ func TestStream_lostItem(t *testing.T) {
 	s.stopWait()
 }
 
+func TestMinPollTime(t *testing.T) {
+	defer leaktest.Check(t)
+
+	s := newStreamTester(t, ``, eventlog.LogSettings{
+		WindowSize: 30 * time.Second,
+	}, nil)
+
+	s.publish("bad", "whatever")
+
+	// Waiting for an item on a log with no matching events incurs a minimum
+	// wait time and reports no events.
+	ctx := context.Background()
+	filter := &coretypes.EventFilter{Query: `tm.event = 'good'`}
+	var zero cursor.Cursor
+
+	t.Run("NoneMatch", func(t *testing.T) {
+		start := time.Now()
+
+		// Request a very short delay, and affirm we got the server's minimum.
+		rsp, err := s.env.Events(ctx, filter, 1, zero, zero, 10*time.Millisecond)
+		if err != nil {
+			t.Fatalf("Events failed: %v", err)
+		} else if elapsed := time.Since(start); elapsed < time.Second {
+			t.Errorf("Events returned too quickly: got %v, wanted 1s", elapsed)
+		} else if len(rsp.Items) != 0 {
+			t.Errorf("Events returned %d items, expected none", len(rsp.Items))
+		}
+	})
+
+	s.publish("good", "whatever")
+
+	// Waiting for an available matching item incurs no delay.
+	t.Run("SomeMatch", func(t *testing.T) {
+		start := time.Now()
+
+		// Request a long-ish delay and affirm we don't block for it.
+		// Check for this by ensuring we return sooner than the minimum delay,
+		// since we don't know the exact timing.
+		rsp, err := s.env.Events(ctx, filter, 1, zero, zero, 10*time.Second)
+		if err != nil {
+			t.Fatalf("Events failed: %v", err)
+		} else if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Errorf("Events returned too slowly: got %v, wanted immediate", elapsed)
+		} else if len(rsp.Items) == 0 {
+			t.Error("Events returned no items, wanted at least 1")
+		}
+	})
+}
+
 // testItem is a wrapper for comparing item results in a friendly output format
 // for the cmp package.
 type testItem struct {

--- a/rpc/core/events.go
+++ b/rpc/core/events.go
@@ -183,8 +183,11 @@ func EventsWithContext(ctx context.Context,
 		maxItems = 100
 	}
 
+	const minWaitTime = 1 * time.Second
 	const maxWaitTime = 30 * time.Second
-	if waitTime > maxWaitTime {
+	if waitTime < minWaitTime {
+		waitTime = minWaitTime
+	} else if waitTime > maxWaitTime {
 		waitTime = maxWaitTime
 	}
 
@@ -203,7 +206,7 @@ func EventsWithContext(ctx context.Context,
 	accept := func(itm *eventlog.Item) error {
 		// N.B. We accept up to one item more than requested, so we can tell how
 		// to set the "more" flag in the response.
-		if len(items) > maxItems {
+		if len(items) > maxItems || itm.Cursor.Before(after) {
 			return eventlog.ErrStopScan
 		}
 		flattenedEvents := tmquery.FlattenEvents(itm.Events)
@@ -217,7 +220,7 @@ func EventsWithContext(ctx context.Context,
 		return nil
 	}
 
-	if waitTime > 0 && before.IsZero() {
+	if before.IsZero() {
 		ctx, cancel := context.WithTimeout(ctx, waitTime)
 		defer cancel()
 


### PR DESCRIPTION
Please add a description of the changes that this PR introduces and the files that
are the most critical to review.

If this PR fixes an open Issue, please include "Closes #XXX" (where "XXX" is the Issue number) 
so that GitHub will automatically close the Issue when this PR is merged.


